### PR TITLE
Add support for cpu inference

### DIFF
--- a/generativeimage2text/inference.py
+++ b/generativeimage2text/inference.py
@@ -104,11 +104,13 @@ def test_git_inference_single_image(image_path, model_name, prefix):
     input_ids = [tokenizer.cls_token_id] + payload
 
     with torch.no_grad():
-        result = model({
-            'image': img,
-            'prefix': torch.tensor(input_ids).unsqueeze(0),
-        })
-    
+        result = {
+                    'image': img,
+                    'prefix': torch.tensor(input_ids).unsqueeze(0),
+                }
+        if CUDA:
+            result["prefix"] = result["prefix"].cuda()
+        result = model(result)
     cap = tokenizer.decode(result['predictions'][0].tolist(), skip_special_tokens=True)
     logging.info('output: {}'.format(cap))
 


### PR DESCRIPTION
This PR allows non-CUDA devices to run inference.
I have tested this on mac m1. I haven't tested this on a CUDA device
@amsword I think this will be a good addition as it allows users to run inference on less powerful devices to just play with the model.